### PR TITLE
Clean up leftover merge artifacts

### DIFF
--- a/packages/web/src/views/common/SubscribeDownload.vue
+++ b/packages/web/src/views/common/SubscribeDownload.vue
@@ -370,45 +370,7 @@ onTasksCancelFailed((error: any) => {
 const pauseSelected = () => pauseTasks();
 const unpauseSelected = () => unpauseTasks();
 const cancelSelected = () => cancelTasks();
-=======
-const pauseSelected = async () => {
-  batchPausing.value = true;
-  for (const id of selectedIds.value) {
-    try {
-      const item = await api.Download.pause(id)();
-      onItemUpdated(item);
-    } catch (error: any) {
-      toast.toastError(t(`error.${error.response?.data?.code ?? 'other'}`));
-    }
-  }
-  batchPausing.value = false;
-};
 
-const unpauseSelected = async () => {
-  batchUnpausing.value = true;
-  for (const id of selectedIds.value) {
-    try {
-      const item = await api.Download.unpause(id)();
-      onItemUpdated(item);
-    } catch (error: any) {
-      toast.toastError(t(`error.${error.response?.data?.code ?? 'other'}`));
-    }
-  }
-  batchUnpausing.value = false;
-};
-
-const cancelSelected = async () => {
-  batchCanceling.value = true;
-  for (const id of selectedIds.value) {
-    try {
-      const item = await api.Download.cancel(id)();
-      onItemUpdated(item);
-    } catch (error: any) {
-      toast.toastError(t(`error.${error.response?.data?.code ?? 'other'}`));
-    }
-  }
-  batchCanceling.value = false;
-};
 </script>
 
 <style scoped lang="sass"></style>


### PR DESCRIPTION
## Summary
- remove duplicated async loops from `SubscribeDownload.vue`
- restore simple callbacks for pausing/unpausing/canceling selected tasks

## Testing
- `pnpm -r lint` *(fails: eslint and node modules missing)*
- `pnpm -r build` *(fails: vue-tsc/nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848349db2848329b80776e88ca47783