### PR TITLE
Fix duplicate variable declarations

### DIFF
--- a/packages/web/src/views/common/SubscribeDownload.vue
+++ b/packages/web/src/views/common/SubscribeDownload.vue
@@ -306,9 +306,6 @@ const allSelected = computed({
   },
 });
 
-const batchPausing = ref(false);
-const batchUnpausing = ref(false);
-const batchCanceling = ref(false);
 
 const toggleSelectAll = () => {
   allSelected.value = !allSelected.value;


### PR DESCRIPTION
## Summary
- remove duplicate ref variables from SubscribeDownload view

## Testing
- `pnpm run build` *(fails: vue-tsc not found)*
- `pnpm run lint` *(fails: eslint command failed)*

------
https://chatgpt.com/codex/tasks/task_e_684859972f2883298224b89b0060d886